### PR TITLE
feat(view-inspector): Add expand/collapse all for tree view

### DIFF
--- a/lib/core/parser/parser.dart
+++ b/lib/core/parser/parser.dart
@@ -51,7 +51,8 @@ final class Parser {
         token = _getCurrentToken(tokens);
 
         if (token.type != TokenType.Colon) {
-          throw Exception('Expected : in key-value pair');
+          final threeTokenBefore = nodes.values;
+          throw Exception('Expected : in key-value pair. $threeTokenBefore');
         }
         _eatToken();
         token = _getCurrentToken(tokens);

--- a/lib/feature/view_inspector/view/view_inspector_page.dart
+++ b/lib/feature/view_inspector/view/view_inspector_page.dart
@@ -30,6 +30,7 @@ class ViewInspectorPage extends StatelessWidget {
               minSize: width * 0.4,
               child: SizedBox(
                 height: availableHeight,
+                width: width * 0.7,
                 child: UiViewTreeDetailWidget(),
               ),
             ),

--- a/lib/feature/view_inspector/view_model/view_inspector_view_model.dart
+++ b/lib/feature/view_inspector/view_model/view_inspector_view_model.dart
@@ -26,12 +26,18 @@ final class ViewInspectorViewModel extends ChangeNotifier {
   List<TreeNode<Node>> _selectedNode = [];
   List<TreeNode<Node>> get selectedNode => _selectedNode;
 
+  bool _expandAllDetails = false;
+  bool get expandAllDetails => _expandAllDetails;
+  void toggleExpandAll() {
+    _expandAllDetails = !_expandAllDetails;
+    notifyListeners();
+  }
+
   void _logListener(NewLogEvent event) {
     uiState = ViewInspectorUiState(tree: event.tree);
     notifyListeners();
 
     // debugPrint('tree: ${event.tree}');
-
     final filteredTree = _filterNodesWithChildrenOrText(event.tree);
     if (filteredTree is! ObjectNode) return;
 
@@ -128,7 +134,11 @@ final class ViewInspectorViewModel extends ChangeNotifier {
             }
           }
 
-          treeChildren.add(TreeItem(data: Node(key), children: subtree));
+          treeChildren.add(TreeItem(
+            data: Node(key),
+            children: subtree,
+            expanded: _expandAllDetails,
+          ));
         } else if (value is ObjectNode && !hasArrayOrObject) {
           treeChildren.addAll(_buildSeletedAstTree(value));
         } else if (value is StringNode) {
@@ -150,7 +160,9 @@ final class ViewInspectorViewModel extends ChangeNotifier {
       result.add(TreeItem(
         data: Node(name, id: node.id),
         children: treeChildren,
-        expanded: node.value['children'] != null || node.value['text'] != null,
+        expanded: node.value['children'] != null ||
+            node.value['text'] != null ||
+            _expandAllDetails,
       ));
     } else if (node is ArrayNode) {
       for (final child in node.value) {

--- a/lib/feature/view_inspector/widgets/ui_view_tree_detail_widget.dart
+++ b/lib/feature/view_inspector/widgets/ui_view_tree_detail_widget.dart
@@ -28,30 +28,41 @@ class _UiViewTreeDetailWidgetState extends State<UiViewTreeDetailWidget> {
   @override
   Widget build(BuildContext context) {
     return Column(crossAxisAlignment: CrossAxisAlignment.start, children: [
+      // SizedBox(width: double.infinity),
       Gap(10),
-      Text('UIView Tree Detail').small.mono.withPadding(horizontal: 16),
+      Row(children: [
+        Text('UIView Tree Detail').small.mono.withPadding(horizontal: 16),
+        // const Spacer(),
+        GestureDetector(
+          onTap: getIt<ViewInspectorViewModel>().toggleExpandAll,
+          child: Icon(BootstrapIcons.arrowsExpand)
+              .iconSmall()
+              .withMargin(right: 10),
+        ),
+      ]),
       Divider().withPadding(vertical: 10),
-      Flexible(child: _treeWidget()),
+      Expanded(
+        child: TreeView<Node>(
+          expandIcon: true,
+          shrinkWrap: true,
+          nodes: selectedTreeItems,
+          branchLine: BranchLine.path,
+          builder: (_, node) => TreeItemView(
+            leading: Icon(getTreeIcon(node.data.value)).iconXSmall(),
+            onExpand: onExpand(node),
+            child: Text(
+              node.data.value,
+              style: TextStyle(fontWeight: FontWeight.w400),
+            ).medium.mono,
+          ),
+        ),
+      ),
     ]);
   }
 
-  Widget _treeWidget() {
-    return TreeView<Node>(
-      expandIcon: true,
-      shrinkWrap: true,
-      nodes: selectedTreeItems,
-      branchLine: BranchLine.path,
-      builder: (_, node) => TreeItemView(
-        leading: Icon(getTreeIcon(node.data.value)).iconXSmall(),
-        onExpand:
-            TreeView.defaultItemExpandHandler(selectedTreeItems, node, (val) {
-          setState(() => selectedTreeItems = val);
-        }),
-        child: Text(
-          node.data.value,
-          style: TextStyle(fontWeight: FontWeight.w400),
-        ).medium.mono,
-      ),
-    );
+  ValueChanged<bool> onExpand(TreeItem<Node> node) {
+    return TreeView.defaultItemExpandHandler(selectedTreeItems, node, (val) {
+      setState(() => selectedTreeItems = val);
+    });
   }
 }

--- a/lib/test_main.dart
+++ b/lib/test_main.dart
@@ -1,17 +1,37 @@
 import 'dart:io';
 
-import 'package:ignite_dev_tools/core/parser/parser.dart';
-
+import 'core/parser/parser.dart';
+import 'core/parser/token_type.dart';
 import 'core/parser/tokenizer.dart';
 
-void main(List<String> args) {
+void main(List<String> args) async {
   final file = File(
     '/Users/kodenigma/project/side_quest/ignite_dev_tools/debug_two.log',
     // '/Users/kodenigma/project/side_quest/ignite_dev_tools/debug.log',
   );
   final String logs = file.readAsStringSync();
+
+  ASTNode? textNode;
+  // final val = await Isolate.run(() {
   final output = Tokenizer().tokenize(logs);
-  print(output);
+  // print(output);
   final nodes = Parser().parseValue(output);
   print(nodes);
+
+  if (nodes is ObjectNode) textNode = nodes;
+  // return nodes;
+  // });
+
+  // compute(
+  //   (message) => Tokenizer().tokenize(message),
+  //   logs,
+  // );
 }
+
+// Image(systemName: notification.type.iconName)
+//                 .foregroundColor(Color.purple)
+//                 .font(.system(size: 20, weight: .medium))
+//                 .padding(12)
+//                 .background(Color.purple.opacity(0.1))
+//                 .cornerRadius(8)
+//                 .overlay(RoundedRectangle(cornerRadius: 8).stroke(.accent.opacity(0.3), lineWidth: 1))


### PR DESCRIPTION
- Implemented functionality to globally expand or collapse all nodes in the UIView Tree Detail.
- Introduced a dedicated UI icon in the header to trigger the expand/collapse action.
- Adjusted the default width of the tree detail panel to 70% for improved content visibility.
- Enhances user interaction and control over the visualization of complex view hierarchies.